### PR TITLE
Properly implement jumpToItem method

### DIFF
--- a/src/main/java/org/springframework/batch/item/excel/poi/PoiItemReader.java
+++ b/src/main/java/org/springframework/batch/item/excel/poi/PoiItemReader.java
@@ -16,18 +16,20 @@
 
 package org.springframework.batch.item.excel.poi;
 
+import java.io.InputStream;
+
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.springframework.batch.item.excel.AbstractExcelItemReader;
 import org.springframework.batch.item.excel.Sheet;
 
-import java.io.InputStream;
-
 /**
  * {@link org.springframework.batch.item.ItemReader} implementation which uses apache POI
  * to read an Excel file. It will read the file sheet for sheet and row for row. It is
  * based on the {@link org.springframework.batch.item.file.FlatFileItemReader}
+ *
+ * This class is <b>not</b> thread-safe.
  *
  * @param <T> the type
  * @author Marten Deinum


### PR DESCRIPTION
Prior to this commit the jumpToItem method would
only read a single sheet. However it could be that
multiple sheets would hae been involved in getting
to the itemCount as provided.

The fix was to cleanup the doRead method and to use
the doRead method to read upto the correct index. To
prevent memory issues, the rowmapper is temporarily
being swapped for a noop mapper.

Fixes: #13